### PR TITLE
fix: Upgrade actions/github-script to v7, use OPENSOURCE_BOT_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ name: Build and Release (Manual Run) v1.3
 on: 
  workflow_dispatch: # This event allows manual triggering
 
+permissions:
+  contents: write
+
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
@@ -106,9 +109,9 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
           script: |
             try {
                 var changelog = ``;
@@ -134,7 +137,7 @@ jobs:
       - name: Upload Release Artifacts
         uses: actions/upload-release-asset@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
         with:
           asset_path: /tmp/to/${{ env.RELEASE_NAME}}${{ steps.set_tag.outputs.tag }}.zip
           asset_name: ${{ env.RELEASE_NAME}}${{ steps.set_tag.outputs.tag }}.zip
@@ -145,7 +148,7 @@ jobs:
         id: github_changelog
         uses: Helmisek/conventional-changelog-generator@v1.0.6-release
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
           commit-types: "fix:Bug Fixes,feat:Features,doc:Documentation,build:Build Upgrades,BREAKING CHANGE:Enhancements"
           template-path: ".github/workflows/CHANGELOG.tpl.md"
          
@@ -186,9 +189,9 @@ jobs:
             
       - name: Update Release
         id: update_release
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
           script: |
             try {
                 


### PR DESCRIPTION
## Summary
- Upgrade `actions/github-script` from v6 to v7 (Node 20 deprecated)
- Replace `GITHUB_TOKEN` with `OPENSOURCE_BOT_TOKEN` for release creation
- Add `permissions: contents: write` for CodeQL compatibility

## Test plan
- [ ] Run release action manually to verify